### PR TITLE
fix: Correct Jekyll build source path

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./
+          source: ./docs
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
- Updated the Jekyll build source path in `.github/workflows/jekyll-gh-pages.yml` from the repository root (`./`) to the `docs/` directory (`./docs`). This ensures that the `_config.yml` file is correctly picked up during the build process.